### PR TITLE
Bug Fix - Case Sensitivity in the filename

### DIFF
--- a/src/HelloController.js
+++ b/src/HelloController.js
@@ -1,4 +1,4 @@
-import Controller from './lib/Controller';
+import Controller from './lib/controller';
 import nunjucks from 'nunjucks';
 
 function getName(context) {


### PR DESCRIPTION
When this Javascript file was written it was probably written on a windows machine, where case it doesn't matter but on my Debian OS the case is taken into account and the module cannot be found